### PR TITLE
ci: remove pull_request trigger from trivy workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,8 +3,6 @@ name: Security Scan (Trivy)
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   schedule:
     - cron: '0 0 * * 1'
 


### PR DESCRIPTION
Removes the `pull_request` trigger from the Trivy security scan workflow. The workflow will still run on push to `main` and on the weekly Monday cron schedule.